### PR TITLE
Simplify CPU profiling of the code

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -137,13 +137,24 @@ fn main() {
                     PlayMode::Duration(chaos_random())
                 };
 
-                let handles = run(args.count as u8, play_mode);
-                for handle in handles {
-                    let (n, score) = handle.join().unwrap();
+                // If we aren't running games in parallel, run the game on main thread,
+                // for easier profiling
+                if args.count == 1 {
+                    let (n, score) = play(play_mode);
 
                     match play_mode {
                         PlayMode::Iterations(_) => println!("iterations: {n}, score: {score}"),
                         PlayMode::Duration(_) => println!("{n},{score}"),
+                    }
+                } else {
+                    let handles = run(args.count as u8, play_mode);
+                    for handle in handles {
+                        let (n, score) = handle.join().unwrap();
+
+                        match play_mode {
+                            PlayMode::Iterations(_) => println!("iterations: {n}, score: {score}"),
+                            PlayMode::Duration(_) => println!("{n},{score}"),
+                        }
                     }
                 }
             }

--- a/src/mcts/mod.rs
+++ b/src/mcts/mod.rs
@@ -40,6 +40,9 @@ impl Node {
     }
 
     /// Expand the list of children to this node, but don't visit
+
+    // Never inline, to make CPU profiling easier
+    #[inline(never)]
     pub fn generate_children(&mut self, game: &mut Game) {
         self.children = game
             .generate_moves()
@@ -103,6 +106,9 @@ impl Edge {
     ///
     /// # Panics
     /// Panics if no legal moves could be selected from game position
+
+    // Never inline, to make CPU profiling easier
+    #[inline(never)]
     pub fn select(
         &mut self,
         mut game: Game,
@@ -230,6 +236,8 @@ impl Edge {
         heuristics.get_exploration_value(self.mv, self.mean_score, self.visits, parent_visits, game)
     }
 
+    // Never inline, to make CPU profiling easier
+    #[inline(never)]
     fn expand(&mut self, game: Game, heuristics: &mut Heuristics, rng: &mut dyn RngCore) -> Score {
         debug_assert!(self.child.is_none());
 
@@ -257,6 +265,9 @@ impl Edge {
     /// ### Ideas:
     /// * Use heuristics instead of random moves
     /// * Drop rollouts and just use the heuristic to estimate the score
+
+    // Never inline, to make CPU profiling easier
+    #[inline(never)]
     fn rollout(
         mut game: Game,
         heuristics: &mut Heuristics,


### PR DESCRIPTION
Always run single games on the main thread, and forcibly de-inline some large functions