### PR TITLE
Run games in parallel using Rayon

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ burn = { version = "0.16.0", features = [
 rusqlite = "0.32"
 burn-cuda = "0.16.0"
 serde-wasm-bindgen = "0.6.5"
+rayon = "1.10.0"
 
 [dev-dependencies]
 criterion = "0.3.5"


### PR DESCRIPTION
This allows max number of threads to be reduced using RAYON_NUM_THREADS (default to number of logical CPU cores), and is more profiler-friendly